### PR TITLE
update: trigger_typingをtypingにした。

### DIFF
--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -249,7 +249,7 @@ class AFK(commands.Cog, DataManager):
         Aliases
         -------
         s"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         await (await self.get(ctx.author)).set_afk(reason)
         await ctx.reply("Ok")
 

--- a/cogs/blocker.py
+++ b/cogs/blocker.py
@@ -166,7 +166,7 @@ class Blocker(commands.Cog, DataManager):
         Aliases
         -------
         t"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         await self.write(ctx.guild.id, mode)
         await ctx.reply("Ok")
 

--- a/cogs/bulk.py
+++ b/cogs/bulk.py
@@ -107,7 +107,7 @@ class Bulk(commands.Cog):
         * Super smash bros Special
         ```
         """
-        await ctx.trigger_typing()
+        await ctx.typing()
 
         failed_members = []
         sent_count = 0
@@ -182,7 +182,7 @@ class Bulk(commands.Cog):
             If "add" is selected, all privileges will be granted, and if "remove" is selected, all privileges will be revoked.
         role : Name or Mention of the role
             The target role."""
-        await ctx.trigger_typing()
+        await ctx.typing()
         await role.edit(
             permissions=getattr(
                 discord.Permissions, "all" if mode == "add" else "none"
@@ -229,7 +229,7 @@ class Bulk(commands.Cog):
         role : Role's name or mention
             A role witch adds or removes.
         """
-        await ctx.trigger_typing()
+        await ctx.typing()
 
         failed_members = []
 

--- a/cogs/delay_role.py
+++ b/cogs/delay_role.py
@@ -198,7 +198,7 @@ class DelayRole(commands.Cog, DataManager):
         Aliases
         -------
         s"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         await self.write(ctx.guild.id, role.id, delay)
         await ctx.reply("Ok")
 
@@ -230,7 +230,7 @@ class DelayRole(commands.Cog, DataManager):
         Aliases
         -------
         del, d"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         await self.write(ctx.guild.id, role.id, None)
         await ctx.reply("Ok")
 

--- a/cogs/develop.py
+++ b/cogs/develop.py
@@ -87,7 +87,7 @@ class Develop(commands.Cog):
                 "parent": "Admin"})
     async def reload_language(self, ctx):
         """言語データを再読込します。"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         await self.bot.cogs["Language"].update_language()
         await ctx.reply("Ok")
 

--- a/cogs/enjoy.py
+++ b/cogs/enjoy.py
@@ -63,7 +63,7 @@ class Enjoy(commands.Cog):
         Aliases
         -------
         mc"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         async with self.bot.session.get(
             f"https://api.mojang.com/users/profiles/minecraft/{user}"
         ) as r:
@@ -108,7 +108,7 @@ class Enjoy(commands.Cog):
         !lang en
         --------
         Ah, This command language is supported only japanese."""
-        await ctx.trigger_typing()
+        await ctx.typing()
         data = await self.get_nhk()
         embeds = []
         for item in data["item"]:
@@ -160,7 +160,7 @@ class Enjoy(commands.Cog):
         !lang en
         --------
         Ah, This command language is supported only japanese."""
-        await ctx.trigger_typing()
+        await ctx.typing()
         embeds = []
         async for data in self.jin():
             embed = discord.Embed(
@@ -248,7 +248,7 @@ class Enjoy(commands.Cog):
                 {"ja": f"そのファイルタイプは対応していません。\nサポートしている拡張子:{', '.join(self.GAME_SUPPORT_EXTS)}",
                  "en": f"Sorry, I don't know that file type.\nSupported file type:{', '.join(self.GAME_SUPPORT_EXTS)}"}
             )
-        await ctx.trigger_typing()
+        await ctx.typing()
         input_path = f"{self.GAME_BASE_PATH}input_{ctx.author.id}.{at.filename[at.filename.rfind('.'):]}"
         await at.save(input_path)
         await self.make_game_package(

--- a/cogs/force_pinned_message.py
+++ b/cogs/force_pinned_message.py
@@ -226,7 +226,7 @@ class ForcePinnedMessage(commands.Cog, DataManager):
         If it doesn't come down after a while, please try sending a message.  
         Please note that this is to prevent RTs from sending too many messages, which would limit the API."""
         if hasattr(ctx.channel, "topic"):
-            await ctx.trigger_typing()
+            await ctx.typing()
 
             if content.startswith("# "):
                 # もし埋め込みならjsonにする。

--- a/cogs/free_channel.py
+++ b/cogs/free_channel.py
@@ -197,7 +197,7 @@ The name of the created voice channel will include the ID of the person who crea
     @commands.check(freechannel)
     @commands.cooldown(1, 15, commands.BucketType.user)
     async def remove(self, ctx, name=None):
-        await ctx.trigger_typing()
+        await ctx.typing()
         if name is None:
             await ctx.channel.delete()
         else:
@@ -219,7 +219,7 @@ The name of the created voice channel will include the ID of the person who crea
     @commands.check(freechannel)
     @commands.cooldown(1, 300, commands.BucketType.user)
     async def rename(self, ctx, name: str, *, after: str = None):
-        await ctx.trigger_typing()
+        await ctx.typing()
         if after is None:
             await ctx.channel.edit(name=name)
         else:
@@ -255,7 +255,7 @@ The name of the created voice channel will include the ID of the person who crea
             if message.author.bot or not message.content.startswith(("text", "voice")):
                 return
             else:
-                await message.channel.trigger_typing()
+                await message.channel.typing()
 
             # 作成に必要な情報を変数に入れる。max_channelは最大チャンネル数。
             max_channel = int(topic[22:topic.find("\nこ")])

--- a/cogs/gban.py
+++ b/cogs/gban.py
@@ -139,7 +139,7 @@ class GlobalBan(commands.Cog, DataManager):
         !lang en
         --------
         Gban Enable/Disable Switch Command."""
-        await ctx.trigger_typing()
+        await ctx.typing()
         await self.onoff_guild(ctx.guild.id, not await self.get_onoff(ctx.guild.id))
         await ctx.reply("Ok")
 
@@ -171,7 +171,7 @@ class GlobalBan(commands.Cog, DataManager):
         Aliases
         -------
         c"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         data = await self.get(user.id)
         await ctx.reply(embed=discord.Embed(
             title={
@@ -191,7 +191,7 @@ class GlobalBan(commands.Cog, DataManager):
         !lang en
         --------
         Show you gban list."""
-        await ctx.trigger_typing()
+        await ctx.typing()
         embeds = []
 
         for i, row in enumerate(await self.getall()):
@@ -218,7 +218,7 @@ class GlobalBan(commands.Cog, DataManager):
     @gban.command("add")
     @commands.is_owner()
     async def add_user_(self, ctx, user_id: int, *, reason):
-        await ctx.trigger_typing()
+        await ctx.typing()
         await self.add_user(user_id, reason)
 
         for guild in self.bot.guilds:
@@ -241,7 +241,7 @@ class GlobalBan(commands.Cog, DataManager):
     @gban.command("remove")
     @commands.is_owner()
     async def remove_user_(self, ctx, user_id: int):
-        await ctx.trigger_typing()
+        await ctx.typing()
         await self.remove_user(user_id)
 
         for guild in self.bot.guilds:

--- a/cogs/language.py
+++ b/cogs/language.py
@@ -281,7 +281,7 @@ class Language(commands.Cog):
             code = "invalid language code is inserted. 無効な言語コードです。"
             return await ctx.reply(code)
 
-        await ctx.trigger_typing()
+        await ctx.typing()
 
         # データベースに変更内容を書き込む。
         ugid = ctx.author.id if mode == "user" else ctx.guild.id

--- a/cogs/locker.py
+++ b/cogs/locker.py
@@ -113,7 +113,7 @@ class Locker(commands.Cog, DataManager):
             The number of minutes after which RT will automatically unlock.
             The default is 0, which means no automatic unlocking.
             For example, a value of 5 will keep it locked for five minutes."""
-        await ctx.trigger_typing()
+        await ctx.typing()
         time_ = time() + auto_unload * 60 if auto_unload else 0
         if time_ and not await self.exists(ctx.channel.id):
             await self.save(ctx.channel.id, time_)
@@ -146,7 +146,7 @@ class Locker(commands.Cog, DataManager):
         See Also
         --------
         lock : Lock channel."""
-        await ctx.trigger_typing()
+        await ctx.typing()
         if await self.exists(ctx.channel.id):
             await self.delete(ctx.channel.id)
         await ctx.reply(

--- a/cogs/ngnickname.py
+++ b/cogs/ngnickname.py
@@ -130,7 +130,7 @@ class NGNickName(commands.Cog):
         --------
         `rf!ngnick add tasuren`.  
         This is banned because tasuren is the real owner of the server."""
-        await ctx.trigger_typing()
+        await ctx.typing()
 
         async with self.pool.acquire() as conn:
             async with conn.cursor() as cursor:

--- a/cogs/ngword.py
+++ b/cogs/ngword.py
@@ -123,7 +123,7 @@ class NgWord(commands.Cog, DataManager):
         Notes
         -----
         If you have created a log channel for the log output function of the channel plugin, the log will be output there."""
-        await ctx.trigger_typing()
+        await ctx.typing()
         for word in words.splitlines():
             self.add(ctx.guild.id, word)
         await ctx.reply("Ok")
@@ -157,7 +157,7 @@ class NgWord(commands.Cog, DataManager):
         Examples
         --------
         `rf!ngword remove Badngword"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         for word in words.splitlines():
             self.remove(ctx.guild.id, word)
         await ctx.reply("Ok")

--- a/cogs/noicon_notice.py
+++ b/cogs/noicon_notice.py
@@ -94,7 +94,7 @@ class NoIconNotice(commands.Cog, DataManager):
         Aliases
         -------
         nin"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         assert len(text) < 1500, {
             "ja": "文章は1500文字以内である必要があります。",
             "en": "Text must be no more than 1500 characters."

--- a/cogs/original_command.py
+++ b/cogs/original_command.py
@@ -194,7 +194,7 @@ class OriginalCommand(commands.Cog, DataManager):
         --------
         `rf!command set Welcome! off Welcome to RT Server!!`
         `rf!command set Yes on Yes (free ride)`"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         if len(self.data.get(ctx.guild.id, ())) == 50:
             await ctx.reply(
                 {"ja": "五十個より多くは登録できません。",
@@ -234,7 +234,7 @@ class OriginalCommand(commands.Cog, DataManager):
         Aliases
         -------
         del, rm"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         try:
             await self.delete(ctx.guild.id, command)
         except KeyError:

--- a/cogs/person.py
+++ b/cogs/person.py
@@ -150,7 +150,7 @@ class Person(commands.Cog):
             )
             if message:
                 if not message:
-                    await ctx.trigger_typing()
+                    await ctx.typing()
 
                 errors = ""
                 for characters in findall(r"<a?:.+:\d+>|.", emojis):
@@ -220,7 +220,7 @@ class Person(commands.Cog):
         Examples
         --------
         `rf!userinfo tasuren`"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         # もしuser_name_idが指定されなかった場合は実行者のIDにする。
         user, member = None, None
         if user_name_id is None:
@@ -383,7 +383,7 @@ class Person(commands.Cog):
         !lang en
         --------
         ..."""
-        await ctx.trigger_typing()
+        await ctx.typing()
         if (embed := await self.search(word)):
             await ctx.reply(embed=embed)
         else:

--- a/cogs/require_send.py
+++ b/cogs/require_send.py
@@ -313,7 +313,7 @@ class RequireSend(commands.Cog, DataManager):
         Aliases
         -------
         a"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         if timeout <= MAX_TIMEOUT:
             try:
                 await self.write(ctx.guild.id, (channel or ctx.channel).id, 60 * timeout)
@@ -359,7 +359,7 @@ class RequireSend(commands.Cog, DataManager):
         Aliases
         -------
         rm"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         try:
             await self.delete(ctx.guild.id, (channel or ctx.channel).id)
         except AssertionError:

--- a/cogs/rocations.py
+++ b/cogs/rocations.py
@@ -43,7 +43,7 @@ def check(function: CheckFT) -> CheckFT:
     @wraps(function)
     @commands.has_guild_permissions(administrator=True)
     async def new(self: Rocations, ctx: UnionContext, *args, **kwargs):
-        await ctx.trigger_typing()
+        await ctx.typing()
         try:
             return await function(self, ctx, *args, **kwargs)
         except Exception as e:
@@ -189,7 +189,7 @@ class Rocations(commands.Cog):
         Aliases
         -------
         add, reg"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         self._assert_description(description)
         async with self.pool.acquire() as conn:
             async with conn.cursor() as cursor:
@@ -233,7 +233,7 @@ class Rocations(commands.Cog):
         Aliases
         -------
         del, rm, remove"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         async with self.pool.acquire() as conn:
             async with conn.cursor() as cursor:
                 if await self._exists(cursor, ctx.guild.id):
@@ -378,7 +378,7 @@ class Rocations(commands.Cog):
         Increases the display rank on the server board.  
         You can run this command once every 3 hours 55 minutes 06 seconds.  
         You can also run this command with `/raise` or `rf!raise`."""
-        await ctx.trigger_typing()
+        await ctx.typing()
         async with self.pool.acquire() as conn:
             async with conn.cursor() as cursor:
                 await cursor.execute(
@@ -409,7 +409,7 @@ class Rocations(commands.Cog):
     @discord.slash_command("raise", description="Rocationsでのサーバー表示順位を上げます。")
     async def raise_slash(self, interaction: discord.Interaction):
         ctx = Context(self.bot, interaction, self.raise_alias, "rf!raise")
-        await ctx.trigger_typing()
+        await ctx.typing()
         await self.raise_(ctx)
 
 

--- a/cogs/role_keeper.py
+++ b/cogs/role_keeper.py
@@ -177,7 +177,7 @@ class RoleKeeper(commands.Cog, DataManager):
         -------
         rk"""
         if not ctx.invoked_subcommand:
-            await ctx.trigger_typing()
+            await ctx.typing()
             onoff = await self.toggle(ctx.guild.id)
             await ctx.reply(
                 {"ja": f"ロールキーパーを{'ON' if onoff else 'OFF'}にしました。",

--- a/cogs/role_message.py
+++ b/cogs/role_message.py
@@ -283,7 +283,7 @@ class RoleMessage(commands.Cog, DataManager):
         Aliases
         -------
         a"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         await self.write(ctx.guild.id, role.id, ctx.channel.id, mode, content)
         await ctx.reply("Ok")
 
@@ -320,7 +320,7 @@ class RoleMessage(commands.Cog, DataManager):
         Aliases
         -------
         rm"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         await self.delete(ctx.guild.id, role.id, mode)
         await ctx.reply("Ok")
 

--- a/cogs/rtfm.py
+++ b/cogs/rtfm.py
@@ -143,7 +143,7 @@ class rtfm(commands.Cog, name="Documentation"):
             return
 
         if not hasattr(self, "_rtfm_cache"):
-            await ctx.trigger_typing()
+            await ctx.typing()
             await self.build_rtfm_lookup_table(page_types)
 
         cache = list(self._rtfm_cache[key].items())

--- a/cogs/schedule.py
+++ b/cogs/schedule.py
@@ -130,7 +130,7 @@ class schedule(commands.Cog, DataManager):
         Aliases
         -------
         s"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         await self.set_schedule(ctx.author.id, start, end, day, notice, title)
         await ctx.reply("Ok")
 

--- a/cogs/server_tool.py
+++ b/cogs/server_tool.py
@@ -202,7 +202,7 @@ class ServerTool(commands.Cog):
         Aliases
         -------
         timem, tm, たいむましん, タイムマシン, バックトゥザフューチャー"""
-        await ctx.trigger_typing()
+        await ctx.typing()
 
         if 0 < day:
             try:
@@ -392,7 +392,7 @@ class ServerTool(commands.Cog):
         Aliases
         -------
         sm"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         await ctx.channel.edit(slowmode_delay=t)
         await ctx.reply("Ok")
 
@@ -424,7 +424,7 @@ class ServerTool(commands.Cog):
         This command is for those iOS users who cannot set NSFW on iOS. 
         It sets the channel to nsfw if it is not set to nsfw when executed, and unset nsfw if it is set to nsfw."""
         if hasattr(ctx.channel, "topic"):
-            await ctx.trigger_typing()
+            await ctx.typing()
             await ctx.channel.edit(nsfw=not ctx.channel.nsfw)
             await ctx.reply("Ok")
         else:
@@ -539,7 +539,7 @@ class ServerTool(commands.Cog):
         To do this, first put a 🗑️ reaction at the bottom of the messages you want to delete.  
         Then put the same 🗑️ reaction at the top of the message you want to delete.  
         This is the only way to do it. [Example Video](https://youtu.be/cGnnUbVceR8)"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         await ctx.message.delete()
         await ctx.channel.purge(
             limit=200 if count > 200 else count,

--- a/cogs/ticket.py
+++ b/cogs/ticket.py
@@ -243,7 +243,7 @@ class Ticket(commands.Cog, DataManager):
     @commands.has_permissions(manage_channels=True)
     async def tfm(self, ctx: commands.Context, *, content: Union[bool, str]):
         # チケットメッセージ設定用コマンドです。
-        await ctx.trigger_typing()
+        await ctx.typing()
         if isinstance(content, bool) and not content:
             try:
                 await self.delete_message(ctx.guild.id)

--- a/cogs/translator.py
+++ b/cogs/translator.py
@@ -124,7 +124,7 @@ class Translator(commands.Cog):
         See Also
         --------
         translate(channel plugin) : Only for translate channel."""
-        await ctx.trigger_typing()
+        await ctx.typing()
 
         if lang == "auto":
             # もし自動で翻訳先を判別するなら英文字が多いなら日本語にしてそれ以外は英語にする。

--- a/cogs/twitter.py
+++ b/cogs/twitter.py
@@ -355,7 +355,7 @@ class TwitterNotification(commands.Cog, DataManager, AsyncStream):
         Aliases
         -------
         s"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         try:
             if username in self.user_cache:
                 del self.user_cache[username]

--- a/cogs/url_checker.py
+++ b/cogs/url_checker.py
@@ -114,7 +114,7 @@ class UrlChecker(commands.Cog, DataManager):
             )
         if not force:
             self.runnings.append(ctx.author.id)
-            await ctx.trigger_typing()
+            await ctx.typing()
         try:
             data = await securl.check(self.bot.session, url)
         except ValueError:
@@ -180,7 +180,7 @@ class UrlChecker(commands.Cog, DataManager):
         !lang en
         --------
         ..."""
-        await ctx.trigger_typing()
+        await ctx.typing()
         await ctx.reply(
             f"{'on' if await self.onoff(ctx.guild.id) else 'off'}にしました。"
         )
@@ -222,7 +222,7 @@ class UrlChecker(commands.Cog, DataManager):
             ]
             if len(urls) < 4:
                 ctx = await self.bot.get_context(reaction.message)
-                await ctx.trigger_typing()
+                await ctx.typing()
                 for url in urls:
                     self.bot.loop.create_task(
                         self.securl(ctx, url=url, force=True, author=user)

--- a/cogs/voice_channel.py
+++ b/cogs/voice_channel.py
@@ -221,7 +221,7 @@ class VCChannel(commands.Cog, DataManager):
         -----
         If you want to remove the configuration, set the `template` argument to `off`.  
         There is a fifteen-second cooldown for channel creation."""
-        await ctx.trigger_typing()
+        await ctx.typing()
         if isinstance(template, bool) and not template:
             try:
                 await self.delete(channel.id, mode)

--- a/cogs/voice_role.py
+++ b/cogs/voice_role.py
@@ -161,7 +161,7 @@ class VoiceRole(commands.Cog, DataManager):
         Aliases
         -------
         vr"""
-        await ctx.trigger_typing()
+        await ctx.typing()
         try:
             mode = await self.write(ctx.guild.id, channel.id, role.id)
         except OverflowError:
@@ -171,7 +171,7 @@ class VoiceRole(commands.Cog, DataManager):
 
     @commands.command()
     async def vrall(self, ctx, *, role: discord.Role):
-        await ctx.trigger_typing()
+        await ctx.typing()
         for channel in ctx.guild.voice_channels:
             try:
                 await self.write(ctx.guild.id, channel.id, role.id)

--- a/util/debug.py
+++ b/util/debug.py
@@ -131,7 +131,7 @@ class Debug(commands.Cog):
     @debug.command()
     @require_admin
     async def monitor(self, ctx):
-        await ctx.trigger_typing()
+        await ctx.typing()
         await ctx.reply(
             embed=await self.make_monitor_embed()
         )

--- a/util/settings.py
+++ b/util/settings.py
@@ -63,7 +63,7 @@ class Context:
         self.replied = Event()
         self.replied_content: Optional[str] = None
 
-    async def trigger_typing(self):
+    async def typing(self):
         ...
 
     async def send(

--- a/util/websocket.py
+++ b/util/websocket.py
@@ -123,7 +123,7 @@ def websocket(
 
     @commands.command()
     async def start(self, ctx: commands.Context):
-        await ctx.trigger_typing()
+        await ctx.typing()
         await self.ws_test.connect()
         data = await self.ping.wait()
         await ctx.reply(f"From backend : {data}")


### PR DESCRIPTION
最新のdiscord.py 2.0で`trigger_typing`が削除された。
また、with構文でないと使えない`typing`が`await`で使えるようになった。
このPRは`trigger_typing`を`typing`に交換して最新に対応しただけ。